### PR TITLE
Update Node to v20 in GH actions

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -19,12 +19,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [18.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: cd api && npm ci

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/scraper-tests.yml
+++ b/.github/workflows/scraper-tests.yml
@@ -19,12 +19,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [18.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: cd scraper && npm ci

--- a/.github/workflows/scraper-tests.yml
+++ b/.github/workflows/scraper-tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -13,17 +13,17 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [18.x]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: 'master'
         persist-credentials: false
         fetch-depth: 0
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - run: cd scraper && npm ci


### PR DESCRIPTION
This should fix the issue where playlist data updates are failing: 
https://github.com/patrickgalbraith/rageagain/actions/runs/11479473393/job/31945851112

I tested by running node 12 locally, and was able to replicate the issue shown in the workflow. Updating to Node 18 made the scraper able to pass the test suite, but 20 is required to pass the api test suite. So I updated everything to Node 20.

While I was there I also updated the steps versions, hope that's okay.